### PR TITLE
Hide install directory in home

### DIFF
--- a/firefox.sh
+++ b/firefox.sh
@@ -9,7 +9,7 @@ fi
 
 BASEDIR="/usr/share/firefox-stub"
 SFILE="${BASEDIR}/firefox-${VERSION}.tar"
-FIREFOX_INSTALL_DIR=${FIREFOX_INSTALL_DIR:-"${HOME}/firefox"}
+FIREFOX_INSTALL_DIR=${FIREFOX_INSTALL_DIR:-"${HOME}/.firefox"}
 LFILE="${FIREFOX_INSTALL_DIR}/firefox"
 # p11-kit provides a "bridge" for libnss to access the trust information
 NSSCKBI="${FIREFOX_INSTALL_DIR}/libnssckbi.so"


### PR DESCRIPTION
I found it really distracting having `firefox` in home so I moved it to `.firefox` so I don't see it. I believe that this should be fine, I thought of having a `$HOME/bin` but maybe the user creates that so that might not work.

I realise that you can change the environment variable but I think this may be a more suitable default.